### PR TITLE
Add gRPC tools for required platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN --mount=target=/build-scripts,type=bind,source=scripts \
 
 # Install Go compiler and linter
 RUN --mount=target=/build-scripts,type=bind,source=scripts \
-    GOLANG_VERSION=1.13.7 \
-    GOLANG_SHA256=b3dd4bd781a0271b33168e627f7f43886b4c5d1c794a4015abf34e99c6526ca3 \
+    GOLANG_VERSION=1.14 \
+    GOLANG_SHA256=08df79b46b0adf498ea9f320a0f23d6ec59e9003660b4c9c1ce8e5e2c6f823ca \
     GOLANGCI_LINT_VERSION=1.18.0 \
     /build-scripts/install-go.sh
 
@@ -43,6 +43,17 @@ RUN --mount=target=/build-scripts,type=bind,source=scripts \
     --mount=target=/var/cache/apt,type=cache \
     DOTNET_SDK_VERSION=3.1 \
     /build-scripts/install-dotnet.sh
+
+# Install Protocol Buffers compiler and various GRPC generators
+RUN --mount=target=/build-scripts,type=bind,source=scripts \
+    PROTOC_VERSION=3.11.4 \
+    PROTOC_SHA256=6d0f18cd84b918c7b3edd0203e75569e0c8caecb1367bbbe409b45e28514f5be \
+    PROTOC_GEN_GO_VERSION=1.3.3 \
+    NODEJS_GRPC_VERSION=1.24.2 \
+    NODEJS_GRPC_TOOLS_VERSION=1.8.1 \
+    PYTHON_GRPCIO_VERSION=1.27.2 \
+    PYTHON_GRPCIO_TOOLS_VERSION=1.27.2 \
+    /build-scripts/install-protobuf-tools.sh
 
 # Install Pulumi build tools
 RUN --mount=target=/build-scripts,type=bind,source=scripts \

--- a/scripts/install-packages.sh
+++ b/scripts/install-packages.sh
@@ -18,7 +18,8 @@ apt-get install -y \
 	git \
 	gnupg2 \
 	jq \
-	software-properties-common
+	software-properties-common \
+	unzip
 
 add-apt-repository universe
 apt-get update

--- a/scripts/install-protobuf-tools.sh
+++ b/scripts/install-protobuf-tools.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+#shellcheck source=utils.sh
+source "${SCRIPT_ROOT}/utils.sh"
+
+ensureSet "${PROTOC_VERSION}" "PROTOC_VERSION" || exit 1
+ensureSet "${PROTOC_SHA256}" "PROTOC_SHA256" || exit 1
+ensureSet "${PROTOC_GEN_GO_VERSION}" "PROTOC_GEN_GO_VERSION" || exit 1
+ensureSet "${NODEJS_GRPC_VERSION}" "NODEJS_GRPC_VERSION" || exit 1
+ensureSet "${NODEJS_GRPC_TOOLS_VERSION}" "NODEJS_GRPC_TOOLS_VERSION" || exit 1
+ensureSet "${PYTHON_GRPCIO_VERSION}" "PYTHON_GRPCIO_VERSION" || exit 1
+ensureSet "${PYTHON_GRPCIO_TOOLS_VERSION}" "PYTHON_GRPCIO_TOOLS_VERSION" || exit 1
+
+# Install Protocol Buffers Compiler
+curl --silent -qL \
+    -o /tmp/protoc.zip \
+    "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+
+verifySHASUM "/tmp/protoc.zip" "${PROTOC_SHA256}" || exit 1
+mkdir -p /tmp/protoc
+unzip /tmp/protoc.zip -d /tmp/protoc
+mv /tmp/protoc/bin/protoc /usr/bin/protoc
+mv /tmp/protoc/include/* /usr/include
+rm -rf /tmp/protoc
+rm -rf /tmp/protoc.zip
+
+# Install protoc-gen-go
+pushd /tmp
+git clone https://github.com/golang/protobuf -b "v${PROTOC_GEN_GO_VERSION}" --single-branch --depth 1
+pushd /tmp/protobuf/protoc-gen-go
+/usr/local/go/bin/go install
+popd
+rm -rf /tmp/protobuf
+
+# Install Node gRPC Tools
+npm install --unsafe-perm -g "grpc@${NODEJS_GRPC_VERSION}" "grpc-tools@${NODEJS_GRPC_TOOLS_VERSION}"
+
+# Install the Python gRPC Tools
+pip3 install --user "grpcio==${PYTHON_GRPCIO_VERSION}"
+pip3 install --user "grpcio-tools==${PYTHON_GRPCIO_TOOLS_VERSION}"


### PR DESCRIPTION
Currently gRPC generation is done in a container built from a [separate image](https://github.com/pulumi/pulumi/blob/master/sdk/proto/Dockerfile) from this which is checked into the main `pulumi/pulumi` repo.

This commit adds in the relevant tooling in order that code generation can all be done in a single image with up-to-date dependencies.