### PR TITLE
Use GOBIN when installing Go Binaries

### DIFF
--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -35,4 +35,4 @@ curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | 
 #
 # gocovmerge does not publish versioned releases, but it also hasn't been updated
 # in two years, so getting HEAD is pretty safe.
-/usr/local/go/bin/go get -v github.com/wadey/gocovmerge
+GOBIN=/usr/local/bin /usr/local/go/bin/go get -v github.com/wadey/gocovmerge

--- a/scripts/install-protobuf-tools.sh
+++ b/scripts/install-protobuf-tools.sh
@@ -32,8 +32,8 @@ rm -rf /tmp/protoc.zip
 # Install protoc-gen-go
 pushd /tmp
 git clone https://github.com/golang/protobuf -b "v${PROTOC_GEN_GO_VERSION}" --single-branch --depth 1
-pushd /tmp/protobuf/protoc-gen-go
-/usr/local/go/bin/go install
+pushd /tmp/protobuf
+GOBIN=/usr/local/bin /usr/local/go/bin/go install github.com/golang/protobuf/protoc-gen-go
 popd
 rm -rf /tmp/protobuf
 

--- a/scripts/install-pulumi-tools.sh
+++ b/scripts/install-pulumi-tools.sh
@@ -23,4 +23,4 @@ tar -C /usr/local/bin -xzf /tmp/tf2pulumi.tar.gz
 rm /tmp/tf2pulumi.tar.gz
 
 # Install gomod-doccopy
-/usr/local/go/bin/go get -v github.com/pulumi/scripts/gomod-doccopy
+GOBIN=/usr/local/bin /usr/local/go/bin/go get -v github.com/pulumi/scripts/gomod-doccopy


### PR DESCRIPTION
This sets GOBIN=/usr/local/bin to ensure that all installed Go applications are available on the PATH and not inside /root/go/bin, which is the default GOPATH.